### PR TITLE
fix wininet wrapper

### DIFF
--- a/common/wininet/wininet_windows.go
+++ b/common/wininet/wininet_windows.go
@@ -52,7 +52,7 @@ type internetPerConnOptionList struct {
 
 type internetPerConnOption struct {
 	dwOption uint32
-	value    [8]byte
+	value    uint64
 }
 
 func internetSetOption(option uintptr, lpBuffer uintptr, dwBufferSize uintptr) error {


### PR DESCRIPTION
log from sing-box like:
```
start service: set system proxy: InternetSetOption(Direct): The parameter is incorrect.
```
and in https://github.com/SagerNet/sing-box/blob/dfa10d4ebe54da4b8185c48c7c0af59b8ae3a9da/common/settings/proxy_windows.go#L10, `local` should be `<local>` (to set `Don't use the proxy server for local (intranet) addresses` checked)