### PR TITLE
Trojan: fetch alpn in fallback

### DIFF
--- a/common/metadata/metadata.go
+++ b/common/metadata/metadata.go
@@ -4,4 +4,5 @@ type Metadata struct {
 	Protocol    string
 	Source      Socksaddr
 	Destination Socksaddr
+	Alpn        string
 }


### PR DESCRIPTION
Trojan multi fallback address supporting h2/http1.1 pre-request