### PR TITLE
Improve buffer write string

### DIFF
--- a/common/buf/buffer.go
+++ b/common/buf/buffer.go
@@ -229,8 +229,16 @@ func (b *Buffer) WriteRune(s rune) (int, error) {
 	return b.Write([]byte{byte(s)})
 }
 
-func (b *Buffer) WriteString(s string) (int, error) {
-	return b.Write([]byte(s))
+func (b *Buffer) WriteString(s string) (n int, err error) {
+	if len(s) == 0 {
+		return
+	}
+	if b.IsFull() {
+		return 0, io.ErrShortBuffer
+	}
+	n = copy(b.data[b.end:], s)
+	b.end += n
+	return
 }
 
 func (b *Buffer) WriteZero() error {

--- a/common/metadata/serializer.go
+++ b/common/metadata/serializer.go
@@ -200,5 +200,5 @@ func WriteSocksString(buffer *buf.Buffer, str string) error {
 	if err != nil {
 		return err
 	}
-	return rw.WriteString(buffer, str)
+	return common.Error(buffer.WriteString(str))
 }


### PR DESCRIPTION
Both `[]byte(string)` and `copy([]byte, string)` are zero-alloc for this operation, but `copy([]byte, string)` is faster since Go supports it as a feature.