### PR TITLE
Improve UVariantLen

### DIFF
--- a/common/rw/varint.go
+++ b/common/rw/varint.go
@@ -27,12 +27,28 @@ func ReadUVariant(reader io.Reader) (uint64, error) {
 }
 
 func UVariantLen(x uint64) int {
-	i := 0
-	for x >= 0x80 {
-		x >>= 7
-		i++
+	switch {
+	case x < 1<<(7*1):
+		return 1
+	case x < 1<<(7*2):
+		return 2
+	case x < 1<<(7*3):
+		return 3
+	case x < 1<<(7*4):
+		return 4
+	case x < 1<<(7*5):
+		return 5
+	case x < 1<<(7*6):
+		return 6
+	case x < 1<<(7*7):
+		return 7
+	case x < 1<<(7*8):
+		return 8
+	case x < 1<<(7*9):
+		return 9
+	default:
+		return 10
 	}
-	return i + 1
 }
 
 func WriteUVariant(writer io.Writer, value uint64) error {


### PR DESCRIPTION
```
cpu: Intel(R) Xeon(R) Gold 6161 CPU @ 2.20GHz
BenchmarkOldULEB128Len
BenchmarkOldULEB128Len-16       220905705                5.285 ns/op           0 B/op          0 allocs/op
BenchmarkNewULEB128Len
BenchmarkNewULEB128Len-16       1000000000               0.4078 ns/op          0 B/op          0 allocs/op
PASS
```
Also fixed a typo in filename :-)