### PR TITLE
Fix socks udp behavior

### DIFF
--- a/protocol/socks/client.go
+++ b/protocol/socks/client.go
@@ -142,9 +142,6 @@ func (c *Client) DialContext(ctx context.Context, network string, address M.Sock
 		if command == socks5.CommandConnect {
 			return tcpConn, nil
 		}
-		if response.Bind.Addr.IsUnspecified() {
-			response.Bind = c.serverAddr
-		}
 		udpConn, err := c.dialer.DialContext(ctx, N.NetworkUDP, response.Bind)
 		if err != nil {
 			tcpConn.Close()

--- a/protocol/socks/client.go
+++ b/protocol/socks/client.go
@@ -142,6 +142,9 @@ func (c *Client) DialContext(ctx context.Context, network string, address M.Sock
 		if command == socks5.CommandConnect {
 			return tcpConn, nil
 		}
+		if response.Bind.Addr.IsUnspecified() {
+			response.Bind = c.serverAddr
+		}
 		udpConn, err := c.dialer.DialContext(ctx, N.NetworkUDP, response.Bind)
 		if err != nil {
 			tcpConn.Close()

--- a/protocol/socks/handshake.go
+++ b/protocol/socks/handshake.go
@@ -206,12 +206,13 @@ func HandleConnection0(ctx context.Context, conn net.Conn, version byte, authent
 			metadata.Destination = request.Destination
 			var innerError error
 			done := make(chan struct{})
+			associatePacketConn := NewAssociatePacketConn(udpConn, request.Destination, conn)
 			go func() {
-				defer conn.Close()
-				innerError = handler.NewPacketConnection(ctx, NewAssociatePacketConn(udpConn, request.Destination, conn), metadata)
+				innerError = handler.NewPacketConnection(ctx, associatePacketConn, metadata)
 				close(done)
 			}()
 			err = common.Error(io.Copy(io.Discard, conn))
+			associatePacketConn.Close()
 			<-done
 			return E.Errors(innerError, err)
 		default:


### PR DESCRIPTION
~1. Client: When the server returns an empty address, use the server's address to connect.~
2. Server: Terminate UDP processing when associate TCP connection is closed.