### PR TITLE
Fix isConnect logic mistake

### DIFF
--- a/common/uot/server.go
+++ b/common/uot/server.go
@@ -60,7 +60,7 @@ func (c *ServerConn) loopInput() {
 	for {
 		var destination M.Socksaddr
 		var err error
-		if !c.isConnect {
+		if c.isConnect {
 			destination = c.destination
 		} else {
 			destination, err = AddrParser.ReadAddrPort(c.inputReader)


### PR DESCRIPTION
The code was not tested completely, and in fact, because of a logical mistake, the UDP packet was not successfully forwarded