### PR TITLE
fix task cancelContext

### DIFF
--- a/common/task/task.go
+++ b/common/task/task.go
@@ -56,7 +56,7 @@ func (g *Group) RunContextList(contextList []context.Context) error {
 	}
 
 	taskContext, taskFinish := common.ContextWithCancelCause(context.Background())
-	taskCancelContext, taskCancel := common.ContextWithCancelCause(context.Background())
+	taskCancelContext, taskCancel := common.ContextWithCancelCause(contextList[0])
 
 	var errorAccess sync.Mutex
 	var returnError error
@@ -87,10 +87,6 @@ func (g *Group) RunContextList(contextList []context.Context) error {
 	}
 
 	selectedContext, upstreamErr := common.SelectContext(append([]context.Context{taskCancelContext}, contextList...))
-
-	if selectedContext == 0 {
-		taskCancel(upstreamErr)
-	}
 
 	if g.cleanup != nil {
 		g.cleanup()


### PR DESCRIPTION
we want the task to be cancelled when the upstream context is cancelled, so it's better to build the taskCancelContext upon the upstream context so that it can automatically be cancelled once the upstream context is done. we don't need to manually cancel the context when the upstream context is done this way.