### PR TITLE
修复 复用socks5 udp连接时连接失败问题

### DIFF
--- a/protocol/socks/packet.go
+++ b/protocol/socks/packet.go
@@ -49,20 +49,20 @@ func (c *AssociatePacketConn) RemoteAddr() net.Addr {
 
 //warn:unsafe
 func (c *AssociatePacketConn) ReadFrom(p []byte) (n int, addr net.Addr, err error) {
-	n, addr, err = c.NetPacketConn.ReadFrom(p)
+	n, _, err = c.NetPacketConn.ReadFrom(p)
 	if err != nil {
 		return
 	}
 	if n < 3 {
 		return 0, nil, ErrInvalidPacket
 	}
-	c.remoteAddr = M.SocksaddrFromNet(addr)
 	reader := bytes.NewReader(p[3:n])
 	destination, err := M.SocksaddrSerializer.ReadAddrPort(reader)
 	if err != nil {
 		return
 	}
 	addr = destination.UDPAddr()
+	c.remoteAddr = M.SocksaddrFromNet(addr)
 	index := 3 + int(reader.Size()) - reader.Len()
 	n = copy(p, p[index:n])
 	return
@@ -95,19 +95,19 @@ func (c *AssociatePacketConn) Write(b []byte) (n int, err error) {
 }
 
 func (c *AssociatePacketConn) ReadPacket(buffer *buf.Buffer) (destination M.Socksaddr, err error) {
-	destination, err = c.NetPacketConn.ReadPacket(buffer)
+	_, err = c.NetPacketConn.ReadPacket(buffer)
 	if err != nil {
 		return M.Socksaddr{}, err
 	}
 	if buffer.Len() < 3 {
 		return M.Socksaddr{}, ErrInvalidPacket
 	}
-	c.remoteAddr = destination
 	buffer.Advance(3)
 	destination, err = M.SocksaddrSerializer.ReadAddrPort(buffer)
 	if err != nil {
 		return
 	}
+	c.remoteAddr = destination
 	return destination.Unwrap(), nil
 }
 

--- a/protocol/socks/packet_wait.go
+++ b/protocol/socks/packet_wait.go
@@ -29,7 +29,7 @@ func (w *AssociatePacketReadWaiter) InitializeReadWaiter(options N.ReadWaitOptio
 }
 
 func (w *AssociatePacketReadWaiter) WaitReadPacket() (buffer *buf.Buffer, destination M.Socksaddr, err error) {
-	buffer, destination, err = w.readWaiter.WaitReadPacket()
+	buffer, _, err = w.readWaiter.WaitReadPacket()
 	if err != nil {
 		return
 	}
@@ -37,12 +37,12 @@ func (w *AssociatePacketReadWaiter) WaitReadPacket() (buffer *buf.Buffer, destin
 		buffer.Release()
 		return nil, M.Socksaddr{}, ErrInvalidPacket
 	}
-	w.conn.remoteAddr = destination
 	buffer.Advance(3)
 	destination, err = M.SocksaddrSerializer.ReadAddrPort(buffer)
 	if err != nil {
 		buffer.Release()
 		return nil, M.Socksaddr{}, err
 	}
+	w.conn.remoteAddr = destination
 	return
 }


### PR DESCRIPTION
https://github.com/SagerNet/sing-box/issues/1757
在socks5 udp连接复用的情况下连接报错，remoteAddr会被代理地址覆盖，导致流量错误。

![lQLPJwssNY138R3NA_nNBtywaPruP4PcUH0GKjkRVSvtAQ_1756_1017](https://github.com/SagerNet/sing/assets/52657276/73044a82-9101-4b5c-a2bb-8934cb0fc5a3)
![lQLPJx--Lvq30R3NBAHNB3uwBBk8xWaYwt8GKjkRVSvtAA_1915_1025](https://github.com/SagerNet/sing/assets/52657276/735c51bd-9606-49de-b884-e85366c2c32e)
