### PR TITLE
Fix UDP-based DNS (plain/DoH3/DoQ) through SOCKS5 outbound

### DIFF
--- a/protocol/socks/packet.go
+++ b/protocol/socks/packet.go
@@ -85,9 +85,10 @@ func (c *AssociatePacketConn) WriteTo(p []byte, addr net.Addr) (n int, err error
 	return bufio.WritePacketBuffer(c.NetPacketConn, buffer, c.remoteAddr)
 }
 
-func (c *AssociatePacketConn) Read(b []byte) (n int, err error) {
-	n, _, err = c.ReadFrom(b)
-	return
+func (c *AssociatePacketConn) Read(b []byte) (int, error) {
+	n, addr, err := c.ReadFrom(b)
+	c.remoteAddr = M.SocksaddrFromNet(addr)
+	return n, err
 }
 
 func (c *AssociatePacketConn) Write(b []byte) (n int, err error) {


### PR DESCRIPTION
Fix UDP-based DNS (plain/DoH3/DoQ) through SOCKS5 outbound.

`Read` actually calls `ReadFrom`, so either modify `Read`, or remove the line `c.remoteAddr = M.SocksaddrFromNet(addr)` in `ReadFrom`.

To reproduce:
client config
```jsonc
{
	"log": {
		"level": "debug"
	},
	"dns": {
		"servers": [
			{
				"address": "223.5.5.5" // or any UDP/DoH3/DoQ server
			}
		],
		"disable_cache": true
	},
	"inbounds": [
		{
			"type": "socks",
			"listen": "127.0.0.1",
			"listen_port": 1080,
			"domain_strategy": "ipv4_only"
		}
	],
	"outbounds": [
		{
			"type": "socks",
			"server": "127.0.0.1",
			"server_port": 2080
		}
	]
}
```
server config
```json
{
	"log": {
		"level": "debug"
	},
	"inbounds": [
		{
			"type": "socks",
			"listen": "127.0.0.1",
			"listen_port": 2080
		}
	],
	"outbounds": [
		{
			"type": "direct"
		}
	]
}

```