### PR TITLE
Limit http.Transport max connections, efficiency re-used connections.

### DIFF
--- a/protocol/http/handshake.go
+++ b/protocol/http/handshake.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/sagernet/sing/common"
 	"github.com/sagernet/sing/common/atomic"
@@ -117,6 +118,8 @@ func HandleConnection(ctx context.Context, conn net.Conn, reader *std_bufio.Read
 		var innerErr atomic.TypedValue[error]
 		httpClient := &http.Client{
 			Transport: &http.Transport{
+				MaxIdleConns: 10,
+				IdleConnTimeout: 30 * time.Second,
 				DisableCompression: true,
 				DialContext: func(ctx context.Context, network, address string) (net.Conn, error) {
 					metadata.Destination = M.ParseSocksaddr(address)


### PR DESCRIPTION
This PR will fix sing-box issue [#1902 连接迟迟不回收导致大量too many open files报错](https://github.com/SagerNet/sing-box/issues/1902)

Add `MaxIdleConns:10` and `IdleConnTimeout: 30 * time.Second` to `protocol/http/handshake.go` `http.Transport`, to limit conns and force efficiency re-used conns. 

Ref docs from: https://pkg.go.dev/net/http#hdr-Clients_and_Transports