### PR TITLE
replacing IsDomainName linkname

### DIFF
--- a/common/bufio/copy_direct.go
+++ b/common/bufio/copy_direct.go
@@ -3,19 +3,26 @@ package bufio
 import (
 	"errors"
 	"io"
-	"syscall"
 
 	"github.com/sagernet/sing/common/buf"
 	M "github.com/sagernet/sing/common/metadata"
 	N "github.com/sagernet/sing/common/network"
 )
 
-func copyDirect(source syscall.Conn, destination syscall.Conn, readCounters []N.CountFunc, writeCounters []N.CountFunc) (handed bool, n int64, err error) {
-	rawSource, err := source.SyscallConn()
+func copyDirect(source io.Reader, destination io.Writer, readCounters []N.CountFunc, writeCounters []N.CountFunc) (handed bool, n int64, err error) {
+	if !N.SyscallAvailableForRead(source) || !N.SyscallAvailableForWrite(destination) {
+		return
+	}
+	sourceConn := N.SyscallConnForRead(source)
+	destinationConn := N.SyscallConnForWrite(destination)
+	if sourceConn == nil || destinationConn == nil {
+		return
+	}
+	rawSource, err := sourceConn.SyscallConn()
 	if err != nil {
 		return
 	}
-	rawDestination, err := destination.SyscallConn()
+	rawDestination, err := destinationConn.SyscallConn()
 	if err != nil {
 		return
 	}

--- a/common/bufio/copy_direct.go
+++ b/common/bufio/copy_direct.go
@@ -13,20 +13,12 @@ func copyDirect(source io.Reader, destination io.Writer, readCounters []N.CountF
 	if !N.SyscallAvailableForRead(source) || !N.SyscallAvailableForWrite(destination) {
 		return
 	}
-	sourceConn := N.SyscallConnForRead(source)
-	destinationConn := N.SyscallConnForWrite(destination)
+	sourceReader, sourceConn := N.SyscallConnForRead(source)
+	destinationWriter, destinationConn := N.SyscallConnForWrite(destination)
 	if sourceConn == nil || destinationConn == nil {
 		return
 	}
-	rawSource, err := sourceConn.SyscallConn()
-	if err != nil {
-		return
-	}
-	rawDestination, err := destinationConn.SyscallConn()
-	if err != nil {
-		return
-	}
-	handed, n, err = splice(rawSource, rawDestination, readCounters, writeCounters)
+	handed, n, err = splice(sourceConn, sourceReader, destinationConn, destinationWriter, readCounters, writeCounters)
 	return
 }
 

--- a/common/bufio/splice_stub.go
+++ b/common/bufio/splice_stub.go
@@ -8,6 +8,6 @@ import (
 	N "github.com/sagernet/sing/common/network"
 )
 
-func splice(source syscall.RawConn, destination syscall.RawConn, readCounters []N.CountFunc, writeCounters []N.CountFunc) (handed bool, n int64, err error) {
+func splice(source syscall.RawConn, sourceReader N.SyscallReader, destination syscall.RawConn, destinationWriter N.SyscallWriter, readCounters []N.CountFunc, writeCounters []N.CountFunc) (handed bool, n int64, err error) {
 	return
 }

--- a/common/metadata/domain.go
+++ b/common/metadata/domain.go
@@ -1,6 +1,70 @@
 package metadata
 
-import _ "unsafe" // for linkname
+// IsDomainName checks if a string is a presentation-format domain name
+// (currently restricted to hostname-compatible "preferred name" LDH labels and
+// SRV-like "underscore labels"; see golang.org/issue/12421).
+//
+// This function was originally created here:
+//
+//	https://cs.opensource.google/go/go/+/master:src/net/dnsclient.go;l=76-146;drc=05cbbf985fed823a174bf95cc78a7d44f948fdab
+//
+// and it's being copy-pasted in order to use the same functionality. In the original package,
+// this is a private function that cannot be accessed externally
+func IsDomainName(s string) bool {
+	// The root domain name is valid. See golang.org/issue/45715.
+	if s == "." {
+		return true
+	}
 
-//go:linkname IsDomainName net.isDomainName
-func IsDomainName(domain string) bool
+	// See RFC 1035, RFC 3696.
+	// Presentation format has dots before every label except the first, and the
+	// terminal empty label is optional here because we assume fully-qualified
+	// (absolute) input. We must therefore reserve space for the first and last
+	// labels' length octets in wire format, where they are necessary and the
+	// maximum total length is 255.
+	// So our _effective_ maximum is 253, but 254 is not rejected if the last
+	// character is a dot.
+	l := len(s)
+	if l == 0 || l > 254 || l == 254 && s[l-1] != '.' {
+		return false
+	}
+
+	last := byte('.')
+	nonNumeric := false // true once we've seen a letter or hyphen
+	partlen := 0
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		default:
+			return false
+		case 'a' <= c && c <= 'z' || 'A' <= c && c <= 'Z' || c == '_':
+			nonNumeric = true
+			partlen++
+		case '0' <= c && c <= '9':
+			// fine
+			partlen++
+		case c == '-':
+			// Byte before dash cannot be dot.
+			if last == '.' {
+				return false
+			}
+			partlen++
+			nonNumeric = true
+		case c == '.':
+			// Byte before dot cannot be dot, dash.
+			if last == '.' || last == '-' {
+				return false
+			}
+			if partlen > 63 || partlen == 0 {
+				return false
+			}
+			partlen = 0
+		}
+		last = c
+	}
+	if last == '-' || partlen > 63 {
+		return false
+	}
+
+	return nonNumeric
+}

--- a/common/network/counter.go
+++ b/common/network/counter.go
@@ -39,7 +39,7 @@ func UnwrapCountReader(reader io.Reader, countFunc []CountFunc) (io.Reader, []Co
 		return reader, countFunc
 	}
 	switch u := reader.(type) {
-	case ReadWaiter, ReadWaitCreator, syscall.Conn, SyscallReadCreator:
+	case ReadWaiter, ReadWaitCreator, syscall.Conn, SyscallReader:
 		// In our use cases, counters is always at the top, so we stop when we encounter ReadWaiter
 		return reader, countFunc
 	case WithUpstreamReader:
@@ -60,7 +60,7 @@ func UnwrapCountWriter(writer io.Writer, countFunc []CountFunc) (io.Writer, []Co
 		return writer, countFunc
 	}
 	switch u := writer.(type) {
-	case syscall.Conn, SyscallWriteCreator:
+	case syscall.Conn, SyscallWriter:
 		// In our use cases, counters is always at the top, so we stop when we encounter syscall conn
 		return writer, countFunc
 	case WithUpstreamWriter:
@@ -81,7 +81,7 @@ func UnwrapCountPacketReader(reader PacketReader, countFunc []CountFunc) (Packet
 		return reader, countFunc
 	}
 	switch u := reader.(type) {
-	case PacketReadWaiter, PacketReadWaitCreator, syscall.Conn, SyscallWriteCreator:
+	case PacketReadWaiter, PacketReadWaitCreator, syscall.Conn:
 		// In our use cases, counters is always at the top, so we stop when we encounter ReadWaiter
 		return reader, countFunc
 	case WithUpstreamReader:
@@ -103,7 +103,7 @@ func UnwrapCountPacketWriter(writer PacketWriter, countFunc []CountFunc) (Packet
 		return writer, countFunc
 	}
 	switch u := writer.(type) {
-	case syscall.Conn, SyscallWriteCreator:
+	case syscall.Conn:
 		// In our use cases, counters is always at the top, so we stop when we encounter syscall conn
 		return writer, countFunc
 	case WithUpstreamWriter:

--- a/common/network/direct.go
+++ b/common/network/direct.go
@@ -1,6 +1,10 @@
 package network
 
 import (
+	"io"
+	"syscall"
+
+	"github.com/sagernet/sing/common"
 	"github.com/sagernet/sing/common/buf"
 	M "github.com/sagernet/sing/common/metadata"
 )
@@ -108,4 +112,88 @@ type VectorisedPacketReadWaiter interface {
 
 type VectorisedPacketReadWaitCreator interface {
 	CreateVectorisedPacketReadWaiter() (VectorisedPacketReadWaiter, bool)
+}
+
+type SyscallReadCreator interface {
+	SyscallConnForRead() syscall.Conn
+}
+
+func SyscallAvailableForRead(reader io.Reader) bool {
+	if _, ok := reader.(syscall.Conn); ok {
+		return true
+	}
+	if _, ok := reader.(SyscallReadCreator); ok {
+		return true
+	}
+	if u, ok := reader.(ReaderWithUpstream); !ok || !u.ReaderReplaceable() {
+		return false
+	}
+	if u, ok := reader.(WithUpstreamReader); ok {
+		return SyscallAvailableForRead(u.UpstreamReader().(io.Reader))
+	}
+	if u, ok := reader.(common.WithUpstream); ok {
+		return SyscallAvailableForRead(u.Upstream().(io.Reader))
+	}
+	return false
+}
+
+func SyscallConnForRead(reader io.Reader) syscall.Conn {
+	if c, ok := reader.(syscall.Conn); ok {
+		return c
+	}
+	if c, ok := reader.(SyscallReadCreator); ok {
+		return c.SyscallConnForRead()
+	}
+	if u, ok := reader.(ReaderWithUpstream); !ok || !u.ReaderReplaceable() {
+		return nil
+	}
+	if u, ok := reader.(WithUpstreamReader); ok {
+		return SyscallConnForRead(u.UpstreamReader().(io.Reader))
+	}
+	if u, ok := reader.(common.WithUpstream); ok {
+		return SyscallConnForRead(u.Upstream().(io.Reader))
+	}
+	return nil
+}
+
+type SyscallWriteCreator interface {
+	SyscallConnForWrite() syscall.Conn
+}
+
+func SyscallAvailableForWrite(writer io.Writer) bool {
+	if _, ok := writer.(syscall.Conn); ok {
+		return true
+	}
+	if _, ok := writer.(SyscallWriteCreator); ok {
+		return true
+	}
+	if u, ok := writer.(WriterWithUpstream); !ok || !u.WriterReplaceable() {
+		return false
+	}
+	if u, ok := writer.(WithUpstreamWriter); ok {
+		return SyscallAvailableForWrite(u.UpstreamWriter().(io.Writer))
+	}
+	if u, ok := writer.(common.WithUpstream); ok {
+		return SyscallAvailableForWrite(u.Upstream().(io.Writer))
+	}
+	return false
+}
+
+func SyscallConnForWrite(writer io.Writer) syscall.Conn {
+	if c, ok := writer.(syscall.Conn); ok {
+		return c
+	}
+	if c, ok := writer.(SyscallWriteCreator); ok {
+		return c.SyscallConnForWrite()
+	}
+	if u, ok := writer.(WriterWithUpstream); !ok || !u.WriterReplaceable() {
+		return nil
+	}
+	if u, ok := writer.(WithUpstreamWriter); ok {
+		return SyscallConnForWrite(u.UpstreamWriter().(io.Writer))
+	}
+	if u, ok := writer.(common.WithUpstream); ok {
+		return SyscallConnForWrite(u.Upstream().(io.Writer))
+	}
+	return nil
 }

--- a/common/network/early.go
+++ b/common/network/early.go
@@ -1,5 +1,38 @@
 package network
 
+import (
+	"io"
+
+	"github.com/sagernet/sing/common"
+)
+
+// Deprecated: use EarlyReader and EarlyWriter instead.
 type EarlyConn interface {
 	NeedHandshake() bool
+}
+
+type EarlyReader interface {
+	NeedHandshakeForRead() bool
+}
+
+func NeedHandshakeForRead(reader io.Reader) bool {
+	if earlyReader, isEarlyReader := common.Cast[EarlyReader](reader); isEarlyReader && earlyReader.NeedHandshakeForRead() {
+		return true
+	}
+	return false
+}
+
+type EarlyWriter interface {
+	NeedHandshakeForWrite() bool
+}
+
+func NeedHandshakeForWrite(writer io.Writer) bool {
+	if //goland:noinspection GoDeprecation
+	earlyConn, isEarlyConn := writer.(EarlyConn); isEarlyConn {
+		return earlyConn.NeedHandshake()
+	}
+	if earlyWriter, isEarlyWriter := common.Cast[EarlyWriter](writer); isEarlyWriter && earlyWriter.NeedHandshakeForWrite() {
+		return true
+	}
+	return false
 }

--- a/common/network/name.go
+++ b/common/network/name.go
@@ -10,11 +10,10 @@ var ErrUnknownNetwork = E.New("unknown network")
 
 //goland:noinspection GoNameStartsWithPackageName
 const (
-	NetworkIP     = "ip"
-	NetworkTCP    = "tcp"
-	NetworkUDP    = "udp"
-	NetworkICMPv4 = "icmpv4"
-	NetworkICMPv6 = "icmpv6"
+	NetworkIP   = "ip"
+	NetworkTCP  = "tcp"
+	NetworkUDP  = "udp"
+	NetworkICMP = "icmp"
 )
 
 //goland:noinspection GoNameStartsWithPackageName
@@ -23,6 +22,8 @@ func NetworkName(network string) string {
 		return NetworkTCP
 	} else if strings.HasPrefix(network, "udp") {
 		return NetworkUDP
+	} else if strings.HasPrefix(network, "icmp") {
+		return NetworkICMP
 	} else if strings.HasPrefix(network, "ip") {
 		return NetworkIP
 	} else {

--- a/common/tls/config.go
+++ b/common/tls/config.go
@@ -17,7 +17,7 @@ type Config interface {
 	SetServerName(serverName string)
 	NextProtos() []string
 	SetNextProtos(nextProto []string)
-	Config() (*STDConfig, error)
+	STDConfig() (*STDConfig, error)
 	Client(conn net.Conn) (Conn, error)
 	Clone() Config
 }


### PR DESCRIPTION
This pull request replace the `isDomainName` linkname by a copy-pasted function. Using the linkname for some weird reason breaks tiny-go when trying to generate a WASM file that uses the sing library (this is used for WATER pluggable transport implementations). There's also a minor reason, [per original function documentation](https://cs.opensource.google/go/go/+/master:src/net/dnsclient.go;l=76-146;drc=05cbbf985fed823a174bf95cc78a7d44f948fdab), that function is only intended for internal usage for the `net` package