### PR TITLE
ignore darwin IP_DONTFRAG error when not supported

### DIFF
--- a/common/control/frag_darwin.go
+++ b/common/control/frag_darwin.go
@@ -1,6 +1,7 @@
 package control
 
 import (
+	"errors"
 	"os"
 	"syscall"
 
@@ -18,12 +19,18 @@ func DisableUDPFragment() Func {
 			if network == "udp" || network == "udp4" {
 				err := unix.SetsockoptInt(int(fd), unix.IPPROTO_IP, unix.IP_DONTFRAG, 1)
 				if err != nil {
+					if errors.Is(err, unix.ENOPROTOOPT) || errors.Is(err, unix.EOPNOTSUPP) {
+						return nil
+					}
 					return os.NewSyscallError("SETSOCKOPT IP_DONTFRAG", err)
 				}
 			}
 			if network == "udp" || network == "udp6" {
 				err := unix.SetsockoptInt(int(fd), unix.IPPROTO_IPV6, unix.IPV6_DONTFRAG, 1)
 				if err != nil {
+					if errors.Is(err, unix.ENOPROTOOPT) || errors.Is(err, unix.EOPNOTSUPP) {
+						return nil
+					}
 					return os.NewSyscallError("SETSOCKOPT IPV6_DONTFRAG", err)
 				}
 			}


### PR DESCRIPTION
This fixes UDP dialers on older macOS versions where `IP_DONTFRAG` is not supported, causing errors like:
lookup 2ip.ru: (exchange6: 2ip.ru.: dial udp 192.168.1.1:53: SETSOCKOPT IP_DONTFRAG: protocol not available | exchange4: 2ip.ru.: dial udp 192.168.1.1:53: SETSOCKOPT IP_DONTFRAG: protocol not available)