### PR TITLE
exceptions: classify QUIC StreamError as canceled

### DIFF
--- a/common/exceptions/canceled_quic.go
+++ b/common/exceptions/canceled_quic.go
@@ -1,0 +1,12 @@
+package exceptions
+
+import (
+    "errors"
+
+    "github.com/sagernet/quic-go"
+)
+
+func isCanceledQuic(err error) bool {
+    var se *quic.StreamError
+    return errors.As(err, &se)
+}

--- a/common/exceptions/error.go
+++ b/common/exceptions/error.go
@@ -65,5 +65,5 @@ func IsClosed(err error) bool {
 }
 
 func IsCanceled(err error) bool {
-	return IsMulti(err, context.Canceled, context.DeadlineExceeded)
+	return IsMulti(err, context.Canceled, context.DeadlineExceeded) || isCanceledQuic(err)
 }


### PR DESCRIPTION
When the client performs latency / connectivity checks (e.g. to cp.cloudflare.com:80), it may close/cancel the QUIC stream immediately after receiving a response. This results in errors like:
"connection upload closed: stream X canceled by remote with error code 0"
In this case the stream cancellation is expected/benign (the client is simply aborting the stream after the check), but it is currently not recognized by exceptions.IsClosedOrCanceled(), so callers log it as ERROR.


+0800 2025-12-26 00:00:17 INFO [3793898884 0ms] outbound/direct[direct]: outbound connection to cp.cloudflare.com:80
+0800 2025-12-26 00:00:17 ERROR [3793898884 318ms] connection: connection upload closed: stream 4 canceled by remote with error code 0
+0800 2025-12-26 00:00:37 ERROR [1329480541 8m28s] connection: connection upload closed: stream 16 canceled by remote with error code 0
+0800 2025-12-26 00:00:37 ERROR [3610290981 7m34s] connection: connection upload closed: stream 20 canceled by remote with error code 0
+0800 2025-12-26 00:00:37 ERROR [1887885168 43.78s] connection: connection upload closed: stream 24 canceled by remote with error code 0


