### PR TITLE
exceptions: classify QUIC StreamError as canceled

### DIFF
--- a/common/exceptions/error.go
+++ b/common/exceptions/error.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strings"
 	"syscall"
 	_ "unsafe"
 
@@ -65,5 +66,14 @@ func IsClosed(err error) bool {
 }
 
 func IsCanceled(err error) bool {
-	return IsMulti(err, context.Canceled, context.DeadlineExceeded)
+	return IsMulti(err, context.Canceled, context.DeadlineExceeded) || isCanceledQuicLike(err)
+}
+
+func isCanceledQuicLike(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := err.Error()
+	return strings.Contains(s, "canceled by remote with error code 0") ||
+		strings.Contains(s, "canceled by local with error code 0")
 }


### PR DESCRIPTION
### Problem

When running connectivity / latency checks over QUIC/TUIC, the peer may cancel the stream immediately after the check completes. sing-box then logs this as an ERROR:

```log
+0800 2025-12-26 00:00:17 INFO  outbound/direct[direct]: outbound connection to cp.cloudflare.com:80
+0800 2025-12-26 00:00:17 ERROR connection: connection upload closed: stream 4  canceled by remote with error code 0
+0800 2025-12-26 00:00:37 ERROR connection: connection upload closed: stream 16 canceled by remote with error code 0
+0800 2025-12-26 00:00:37 ERROR connection: connection upload closed: stream 20 canceled by remote with error code 0
+0800 2025-12-26 00:00:37 ERROR connection: connection upload closed: stream 24 canceled by remote with error code 0