### PR TITLE
baderror: Treat HTTP/2 NO_ERROR as closed

### DIFF
--- a/common/baderror/baderror.go
+++ b/common/baderror/baderror.go
@@ -24,7 +24,14 @@ func WrapH2(err error) error {
 	if errors.Is(err, io.ErrUnexpectedEOF) {
 		return io.EOF
 	}
-	if Contains(err, "client disconnected", "body closed by handler", "response body closed", "; CANCEL") {
+	if Contains(
+		err,
+		"client disconnected",
+		"body closed by handler",
+		"response body closed",
+		"; CANCEL",
+		"; NO_ERROR",
+	) {
 		return net.ErrClosed
 	}
 	return err


### PR DESCRIPTION
## baderror: Treat HTTP/2 NO_ERROR as closed

### Problem

sing-box logs spurious error/warning messages when HTTP/2 connections are closed gracefully. The log contains noisy entries like:

```
WARN [...] baderror [...]
```

This is a false positive — the connection closed normally, but the error wrapper misclassifies it.

### Root Cause

In `common/baderror/baderror.go`, the `WrapH2()` function converts various HTTP/2 error messages into harmless sentinel errors (e.g., `net.ErrClosed`). This prevents normal connection teardown from being logged as errors upstream.

HTTP/2 uses a `NO_ERROR` code (0x0) in GOAWAY and RST_STREAM frames to indicate graceful shutdown. When the peer sends `NO_ERROR`, Go's HTTP/2 implementation may return an error string containing `"; NO_ERROR"`. This pattern was not in the recognized list, so it was treated as a genuine error.

### Fix

Added `"; NO_ERROR"` to the recognized patterns in `WrapH2()`:

```go
if Contains(
    err,
    "client disconnected",
    "body closed by handler",
    "response body closed",
    "; CANCEL",
    "; NO_ERROR",       // added
) {
    return net.ErrClosed
}
```

This ensures HTTP/2 graceful shutdown (NO_ERROR) is treated the same as other normal close signals — returning `net.ErrClosed` instead of the raw error, which the caller handles silently.

### Changes

- `common/baderror/baderror.go`: Added `"; NO_ERROR"` to the close detection list

### Testing

- HTTP/2 connections closing with NO_ERROR no longer produce baderror warnings in logs
- Other error types (actual connection errors) continue to be reported correctly