### PR TITLE
bufio: fix relay goroutine leak when one CopyConn direction half-closes

### DIFF
--- a/common/bufio/copy.go
+++ b/common/bufio/copy.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"io"
 	"net"
+	"sync/atomic"
+	"time"
 
 	"github.com/sagernet/sing/common"
 	"github.com/sagernet/sing/common/buf"
@@ -218,10 +220,53 @@ func copyExtendedWithPool(session *CopySession, destination N.ExtendedWriter, so
 	}
 }
 
+// connDoneTimeoutOverride lets tests shorten the teardown deadline. It is nil in
+// production, where the default 30s below is used. Reads are atomic so a test
+// override is race-free even if other CopyConn calls run concurrently.
+var connDoneTimeoutOverride atomic.Pointer[time.Duration]
+
+const defaultConnDoneTimeout = 30 * time.Second
+
+func connDoneDuration() time.Duration {
+	if d := connDoneTimeoutOverride.Load(); d != nil {
+		return *d
+	}
+	return defaultConnDoneTimeout
+}
+
+// setConnDoneDeadline arms a teardown deadline on the conn the surviving copy
+// direction is blocked reading. CopyConn runs two relay goroutines: upload
+// (source -> destination) and download (destination -> source). When one
+// finishes, the other may be parked in the runtime netpoller (epoll_wait) on a
+// Read that never completes: the duplex teardown half-closes the conn's write
+// side via CloseWrite, which leaves the read side open, so a peer that
+// half-closed but never sends FIN keeps the surviving Read parked forever.
+// Nothing else wakes it -- the finished direction returned nil on EOF, so
+// group.Run keeps waiting for the surviving direction, the connection is never
+// closed, and the relay goroutine and its fds leak. The deadline wakes that
+// surviving Read within connDoneDuration.
+//
+// Only the duplex branches call this: CloseWrite half-closes write only, so the
+// surviving Read stays parked. The non-duplex branches call common.Close, which
+// fully closes the conn and wakes the surviving Read immediately, so they need
+// no deadline.
+//
+// Only the conn the surviving direction READS is deadline'd, never the conn it
+// writes: the writer of the deadline'd conn is the just-finished goroutine, so
+// the write portion of SetDeadline is harmless, and deadlining the written conn
+// would truncate a legitimate slow reverse stream. Go deadlines are absolute --
+// a successful Read does not reset them -- so this only affects a direction that
+// has already stalled, not one that completes before the deadline elapses.
+func setConnDoneDeadline(conn net.Conn) {
+	conn.SetDeadline(time.Now().Add(connDoneDuration()))
+}
+
 func CopyConn(ctx context.Context, source net.Conn, destination net.Conn) error {
 	var group task.Group
 	if _, dstDuplex := common.Cast[N.WriteCloser](destination); dstDuplex {
 		group.Append("upload", func(ctx context.Context) error {
+			// Surviving download reads destination; arm its teardown deadline.
+			defer setConnDoneDeadline(destination)
 			err := common.Error(Copy(destination, source))
 			if err == nil {
 				N.CloseWrite(destination)
@@ -238,6 +283,8 @@ func CopyConn(ctx context.Context, source net.Conn, destination net.Conn) error 
 	}
 	if _, srcDuplex := common.Cast[N.WriteCloser](source); srcDuplex {
 		group.Append("download", func(ctx context.Context) error {
+			// Surviving upload reads source; arm its teardown deadline.
+			defer setConnDoneDeadline(source)
 			err := common.Error(Copy(source, destination))
 			if err == nil {
 				N.CloseWrite(source)

--- a/common/bufio/copy_halfclose_test.go
+++ b/common/bufio/copy_halfclose_test.go
@@ -1,0 +1,257 @@
+package bufio
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync"
+	"testing"
+	"time"
+)
+
+// isTimeoutErr reports whether err chains to a net.Error whose Timeout returns
+// true (the error a blocked Read returns after SetDeadline elapses). It traverses
+// Unwrap chains, so it still matches after task.Group wraps the error with a
+// cause message.
+func isTimeoutErr(err error) bool {
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Timeout()
+}
+
+// withConnDoneTimeout temporarily shortens the teardown deadline for the duration
+// of a test. The override is stored atomically, so it is race-free even if other
+// CopyConn calls run concurrently. t.Cleanup restores the default on exit,
+// including when the test fails.
+func withConnDoneTimeout(t *testing.T, d time.Duration) {
+	t.Helper()
+	override := d
+	connDoneTimeoutOverride.Store(&override)
+	t.Cleanup(func() { connDoneTimeoutOverride.Store(nil) })
+}
+
+// closeWrite fails the test if the half-close fails: a failed CloseWrite would
+// mean the test never set up the half-closed state it intends to exercise.
+func closeWrite(t *testing.T, c *net.TCPConn) {
+	t.Helper()
+	if err := c.CloseWrite(); err != nil {
+		t.Fatalf("CloseWrite: %v", err)
+	}
+}
+
+// TestCopyConnHalfCloseDeadline verifies the duplex leak fix: when one copy
+// direction reaches EOF, the surviving direction's blocked Read is woken by the
+// teardown deadline instead of parking forever. TCP pairs are used (not
+// net.Pipe) because the test needs a real half-close via CloseWrite -- the
+// duplex teardown calls CloseWrite, which half-closes write only and leaves the
+// surviving Read parked, which is exactly the condition the deadline fixes.
+func TestCopyConnHalfCloseDeadline(t *testing.T) {
+	withConnDoneTimeout(t, 200*time.Millisecond)
+
+	source, client := tcpPair(t)
+	destination, server := tcpPair(t)
+	defer server.Close()
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- CopyConn(ctx, source, destination) }()
+
+	// Drive one byte through upload (client -> source -> destination -> server)
+	// and drain it on the server side. server.Read succeeding confirms upload
+	// has entered its loop and forwarded the byte.
+	if _, err := client.Write([]byte{0}); err != nil {
+		t.Fatalf("client write: %v", err)
+	}
+	one := make([]byte, 1)
+	if _, err := server.Read(one); err != nil {
+		t.Fatalf("server read handshake byte: %v", err)
+	}
+
+	// Client half-closes its write side -> upload reaches EOF -> duplex
+	// teardown CloseWrite(destination) half-closes write, leaving download
+	// parked in Read on destination. The server never writes again, so only the
+	// teardown deadline can wake download.
+	closeWrite(t, client.(*net.TCPConn))
+
+	select {
+	case err := <-done:
+		// The surviving direction was woken by the deadline, so CopyConn
+		// returns a timeout error rather than blocking until ctx expires.
+		if err == nil {
+			t.Fatal("CopyConn returned nil; expected a timeout from the woken surviving direction")
+		}
+		if !isTimeoutErr(err) {
+			t.Errorf("CopyConn error is not a timeout: %v", err)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("CopyConn did not return within 1s of half-close; teardown deadline not armed")
+	}
+}
+
+// TestCopyConnBothDirectionsClose verifies the deadline does not fire spuriously
+// on a natural close: when both peers half-close, both copy directions reach EOF
+// and CopyConn returns nil promptly. The default 30s deadline never elapses
+// because no direction stalls.
+func TestCopyConnBothDirectionsClose(t *testing.T) {
+	source, client := tcpPair(t)
+	destination, server := tcpPair(t)
+	defer server.Close()
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- CopyConn(ctx, source, destination) }()
+
+	// Handshake bytes both ways so both goroutines enter their loops.
+	if _, err := client.Write([]byte{1}); err != nil {
+		t.Fatalf("client write: %v", err)
+	}
+	if _, err := server.Write([]byte{2}); err != nil {
+		t.Fatalf("server write: %v", err)
+	}
+	one := make([]byte, 1)
+	if _, err := server.Read(one); err != nil {
+		t.Fatalf("server read: %v", err)
+	}
+	if _, err := client.Read(one); err != nil {
+		t.Fatalf("client read: %v", err)
+	}
+
+	// Both sides half-close -> both directions reach EOF naturally -> CopyConn
+	// returns nil well before the default teardown deadline elapses.
+	closeWrite(t, client.(*net.TCPConn))
+	closeWrite(t, server.(*net.TCPConn))
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("CopyConn returned non-nil error on natural close: %v", err)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("CopyConn did not return within 1s of natural close")
+	}
+}
+
+// nonDuplexConn wraps a net.Conn to hide CloseWrite, forcing CopyConn onto the
+// non-duplex teardown path (common.Close, full close). It does not implement
+// WithUpstream or a NetConn() method, so common.Cast[N.WriteCloser] does not
+// unwrap to the underlying TCPConn.
+type nonDuplexConn struct{ net.Conn }
+
+// TestCopyConnNonDuplexCloseWakesPeer verifies the non-duplex path self-heals
+// without a deadline: a full Close on teardown wakes the surviving direction's
+// blocked Read immediately, so CopyConn returns promptly. This is why the patch
+// arms a deadline only in the duplex branches.
+func TestCopyConnNonDuplexCloseWakesPeer(t *testing.T) {
+	source, client := tcpPair(t)
+	destination, server := tcpPair(t)
+	defer server.Close()
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- CopyConn(ctx, nonDuplexConn{source}, nonDuplexConn{destination})
+	}()
+
+	if _, err := client.Write([]byte{0}); err != nil {
+		t.Fatalf("client write: %v", err)
+	}
+	one := make([]byte, 1)
+	if _, err := server.Read(one); err != nil {
+		t.Fatalf("server read handshake byte: %v", err)
+	}
+
+	// Client half-closes -> upload (non-duplex) reaches EOF -> teardown
+	// common.Close(destination) fully closes destination, waking download's
+	// parked Read. No deadline is involved.
+	closeWrite(t, client.(*net.TCPConn))
+
+	select {
+	case <-done:
+		// CopyConn returned: the surviving direction was woken by Close.
+	case <-time.After(1 * time.Second):
+		t.Fatal("CopyConn did not return within 1s; non-duplex Close did not wake surviving direction")
+	}
+}
+
+// TestCopyConnConcurrentOverride runs several relays concurrently while the
+// teardown-deadline override is set, under the race detector. It confirms the
+// atomic override is read safely by concurrent CopyConn calls and that the
+// shortened deadline does not interfere across independent relays.
+func TestCopyConnConcurrentOverride(t *testing.T) {
+	withConnDoneTimeout(t, 200*time.Millisecond)
+
+	const n = 4
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for range n {
+		source, client := tcpPair(t)
+		destination, server := tcpPair(t)
+		defer server.Close()
+		defer client.Close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		go func() {
+			defer wg.Done()
+			done := make(chan error, 1)
+			go func() { done <- CopyConn(ctx, source, destination) }()
+
+			if _, err := client.Write([]byte{0}); err != nil {
+				t.Errorf("client write: %v", err)
+				return
+			}
+			one := make([]byte, 1)
+			if _, err := server.Read(one); err != nil {
+				t.Errorf("server read: %v", err)
+				return
+			}
+			closeWrite(t, client.(*net.TCPConn))
+
+			select {
+			case <-done:
+			case <-time.After(2 * time.Second):
+				t.Errorf("CopyConn did not return within 2s")
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// tcpPair returns a connected loopback TCP conn pair (a, b). The listener is
+// always closed before return so the accept goroutine exits without leaking.
+func tcpPair(t *testing.T) (net.Conn, net.Conn) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		c, err := ln.Accept()
+		if err != nil {
+			close(accepted)
+			return
+		}
+		accepted <- c
+	}()
+	b, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		ln.Close()
+		t.Fatalf("dial: %v", err)
+	}
+	a := <-accepted
+	ln.Close()
+	if a == nil {
+		b.Close()
+		t.Fatalf("accept failed")
+	}
+	return a, b
+}


### PR DESCRIPTION
## Problem

`CopyConn` relays two directions through a `task.Group` whose `Run` waits for
both goroutines to return. When one direction reaches EOF, the duplex teardown
calls `CloseWrite`, which half-closes only the write side. The surviving
direction's `Read` on the still-open read side then parks in the runtime
netpoller (`epoll_wait`) forever if the peer half-closed without sending FIN.
Because the finished direction returned `nil` on EOF (`Copy` converts `io.EOF`
to `nil`), nothing cancels the survivor:

- `group.Run` never returns (still waiting for the surviving direction)
- `group.Cleanup` never runs, so neither conn is closed
- the relay goroutine and both file descriptors leak

In sing-box deployments this surfaced as goroutine and fd counts climbing over
~20 hours until the process hit the fd limit and started returning errors. A
SIGQUIT dump showed goroutines parked in `CopyConn` IO wait on the stuck
connections.

## Fix

Arm a `SetDeadline` on the conn the surviving direction is blocked reading when
a duplex direction finishes, so the parked `Read` wakes within the teardown
timeout instead of blocking forever.

Why this shape:

- **Duplex only.** The non-duplex teardown calls `common.Close` (full close),
  which wakes the surviving `Read` immediately -- no deadline is needed. Only
  `CloseWrite` leaves the read side open.
- **Only the surviving-read conn.** When upload finishes, the survivor is
  download, which reads `destination`; the deadline is armed on `destination`
  only, never on `source`. The writer of the deadline'd conn is the
  just-finished goroutine (already done), so the write portion of
  `SetDeadline` is harmless. Deadlining the conn the survivor *writes* would
  truncate a legitimate slow reverse stream.
- **Absolute deadline.** Go deadlines are absolute -- a successful `Read` does
  not reset them -- so this only fires for a direction that has already
  stalled, not one still transferring data. It is a teardown safety net, not a
  bound on active copy throughput.

## Testing

- `TestCopyConnHalfCloseDeadline`: one direction half-closes via `CloseWrite`;
  with the deadline, `CopyConn` returns within the (shortened) timeout with a
  timeout error. Bug-injected (deadline disabled) it blocks past the test
  deadline -- proving the test exercises the fix.
- `TestCopyConnBothDirectionsClose`: both directions close naturally;
  `CopyConn` returns `nil` promptly, confirming the deadline does not fire
  spuriously on normal close.
- `TestCopyConnNonDuplexCloseWakesPeer`: a conn wrapper that hides
  `CloseWrite` exercises the non-duplex path; `Close` wakes the survivor,
  confirming why no deadline is needed there.
- All pass under `-race`.